### PR TITLE
Fixing WR=NA when no deaths occurred that week

### DIFF
--- a/code/aggregation.R
+++ b/code/aggregation.R
@@ -99,6 +99,10 @@ aggregateMOMO <- function(mi, group) {
   # We clean the data set
   aggr5$nb[is.na(aggr5$nb)] <- 0
   aggr5$nb2[is.na(aggr5$nb2)] <- 0
+  for(i in grep("^WR",names(aggr5))){
+    aggr5[is.na(aggr5[,i]),i] <- 0
+  }
+  
   aggr5[aggr5$wk>=(attr(aggr5, "WEEK") - attr(mi, "histPer")) & aggr5$wk<=(attr(aggr5, "WEEK")+1), ]
 
 }


### PR DESCRIPTION
The current implementation leaves WR0=NA, WR1=NA, ... when no deaths were recorded in a particular week. This fixes that.
